### PR TITLE
Filepath error

### DIFF
--- a/tests/Functional/App/config/config.yml
+++ b/tests/Functional/App/config/config.yml
@@ -17,5 +17,5 @@ doctrine:
             App:
                 is_bundle: false
                 type: annotation
-                dir: '%kernel.project_dir%/Tests/Functional/App/Entity'
+                dir: '%kernel.project_dir%/tests/Functional/App/Entity'
                 prefix: 'AssoConnect\DoctrineValidatorBundle\Tests\Functional\App\Entity'


### PR DESCRIPTION
In the doctrine configuration there is a directory configuration.
There is a typo error in a folder name :
`dir: '%kernel.project_dir%/Tests/Functional/App/Entity'`

The "test" folder may be in lowercase